### PR TITLE
docs: remove duplicate ingress-nginx nav link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,6 @@ nav:
     - Kubecost: 'addons/kubecost.md'
     - Kubeflow: 'addons/kubeflow.md'
     - KubeRay Operator: 'addons/kuberay-operator.md'
-    - Ingress Nginx: 'addons/ingress-nginx.md'
     - Kubeshark: 'addons/kubeshark.md'
     - Kubevious: 'addons/kubevious.md'
     - Kube State Metrics: 'addons/kube-state-metrics.md'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Removing the duplicate AddOns > Ingress Nginx navigation link in the docs site


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
