### PR TITLE
Log addon name that conflicts with auto-mode

### DIFF
--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -87,7 +87,7 @@ export class AwsLoadBalancerControllerAddOn extends HelmAddOn {
         this.options = this.props as AwsLoadBalancerControllerProps;
     }
 
-    @utils.conflictsWithAutoMode(null)
+    @utils.conflictsWithAutoMode(AwsLoadBalancerControllerAddOn.name, null)
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         const cluster = clusterInfo.cluster;
         const serviceAccount = cluster.addServiceAccount(

--- a/lib/addons/coredns/index.ts
+++ b/lib/addons/coredns/index.ts
@@ -41,7 +41,7 @@ export class CoreDnsAddOn extends CoreAddOn {
         });
     }
 
-    @utils.conflictsWithAutoMode("v1.9.3-eksbuild.7")
+    @utils.conflictsWithAutoMode(CoreDnsAddOn.name, "v1.9.3-eksbuild.7")
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
 
         const addonPromise: Promise<Construct> = super.deploy(clusterInfo);

--- a/lib/addons/ebs-csi-driver/index.ts
+++ b/lib/addons/ebs-csi-driver/index.ts
@@ -76,7 +76,7 @@ export class EbsCsiDriverAddOn extends CoreAddOn {
     );
   }
 
-  @utils.conflictsWithAutoMode("v1.37.0-eksbuild.1")
+  @utils.conflictsWithAutoMode(EbsCsiDriverAddOn.name,"v1.37.0-eksbuild.1")
   async deploy(clusterInfo: ClusterInfo): Promise<Construct> {
     const baseDeployment = await super.deploy(clusterInfo);
 

--- a/lib/addons/eks-pod-identity-agent/index.ts
+++ b/lib/addons/eks-pod-identity-agent/index.ts
@@ -28,7 +28,7 @@ const defaultProps = {
  */
 export class EksPodIdentityAgentAddOn extends CoreAddOn {
 
-    @utils.conflictsWithAutoMode('v1.3.4-eksbuild.1')
+    @utils.conflictsWithAutoMode(EksPodIdentityAgentAddOn.name,'v1.3.4-eksbuild.1')
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         return super.deploy(clusterInfo);
     }

--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -116,7 +116,7 @@ export class KarpenterAddOn extends HelmAddOn {
     }
 
     @utils.conflictsWith('ClusterAutoScalerAddOn')
-    @utils.conflictsWithAutoMode("fail")
+    @utils.conflictsWithAutoMode(KarpenterAddOn.name, "fail")
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         assert(clusterInfo.cluster instanceof Cluster, "KarpenterAddOn cannot be used with imported clusters as it requires changes to the cluster authentication.");
         const cluster : Cluster = clusterInfo.cluster;

--- a/lib/addons/kube-proxy/index.ts
+++ b/lib/addons/kube-proxy/index.ts
@@ -30,7 +30,7 @@ const defaultProps = {
 @utils.supportsALL
 export class KubeProxyAddOn extends CoreAddOn {
 
-    @utils.conflictsWithAutoMode(null)
+    @utils.conflictsWithAutoMode(KubeProxyAddOn.name, null)
     deploy(clusterInfo: ClusterInfo): Promise<Construct> {
         return super.deploy(clusterInfo);
     }

--- a/lib/addons/vpc-cni/index.ts
+++ b/lib/addons/vpc-cni/index.ts
@@ -375,7 +375,7 @@ export class VpcCniAddOn extends CoreAddOn {
     (this.coreAddOnProps.configurationValues as any) = populateVpcCniConfigurationValues(props);
   }
 
-  @conflictsWithAutoMode("v1.19.0-eksbuild.1")
+  @conflictsWithAutoMode(VpcCniAddOn.name,"v1.19.0-eksbuild.1")
   deploy(clusterInfo: ClusterInfo): Promise<Construct> {
     const cluster = clusterInfo.cluster;
     let securityGroupId = cluster.clusterSecurityGroupId;

--- a/lib/utils/addon-utils.ts
+++ b/lib/utils/addon-utils.ts
@@ -118,7 +118,7 @@ function parseEksVersion(version: string): [string, number] {
 }
 
 
-export function conflictsWithAutoMode(minExpectedVersion: string | null) {
+export function conflictsWithAutoMode(addOn: string, minExpectedVersion: string | null) {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function(target: Object, key: string | symbol, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
@@ -130,17 +130,17 @@ export function conflictsWithAutoMode(minExpectedVersion: string | null) {
         return originalMethod.apply(this, args);
       }
       if (minExpectedVersion === "fail") {
-        throw new Error(`Deploying ${stack} failed. This add-on is already available on the cluster with EKS Auto Mode.`);
+        throw new Error(`Deploying ${stack} failed. The add-on ${addOn} is already available on the cluster with EKS Auto Mode.`);
       }
       else if (minExpectedVersion == null) {
-        logger.warn(`This add-on is already available on the cluster with EKS Auto Mode.`);
+        logger.warn(`The add-on ${addOn} is already available on the cluster with EKS Auto Mode.`);
         return originalMethod.apply(this, args);
       }
       else if (compareEksVersions(this.version, minExpectedVersion) >= 0){ // what to do if other nodegroups attached too?
-        logger.warn(`This add-on is already available on the cluster with EKS Auto Mode.`);
+        logger.warn(`The add-on ${addOn} is already available on the cluster with EKS Auto Mode.`);
         return originalMethod.apply(this, args);
       } else {
-        throw new Error(`Deploying ${stack} failed. This add-on is already available on the cluster with EKS Auto Mode.  If you would like to install this addon alongside automode, please upgrade to version ${minExpectedVersion}`);
+        throw new Error(`Deploying ${stack} failed. The add-on ${addOn} is already available on the cluster with EKS Auto Mode.  If you would like to install this addon alongside automode, please upgrade to version ${minExpectedVersion}`);
       }
     };
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This changes the warnings/errors that are thrown when an addon conflicts with an auto-mode cluster (or the version). I was getting very frustrated figuring out *which* add-on was the culprit :)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
