### PR TITLE
fix(karpenter): add the compatibility for Kubernetes v1.33

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -21,6 +21,7 @@ export * from './karpenter-v1';
 
 class versionMap {
     private static readonly versionMap: Map<string, string> = new Map([
+        [KubernetesVersion.V1_33.version, '1.5.0'],
         [KubernetesVersion.V1_32.version, '1.2.0'],
         [KubernetesVersion.V1_31.version, '0.37.5'],
         [KubernetesVersion.V1_30.version, '0.37.5'],


### PR DESCRIPTION
*Issue #1173 

*Description of changes:*

Add the compatibility for Kubernetes v1.33
ref: https://karpenter.sh/docs/upgrading/compatibility/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
