### PR TITLE
fix: correct typo in Karpenter aws-auth groups

### DIFF
--- a/lib/addons/karpenter/index.ts
+++ b/lib/addons/karpenter/index.ts
@@ -605,7 +605,7 @@ export class KarpenterAddOn extends HelmAddOn {
 
         // Map Node Role to aws-auth
         cluster.awsAuth.addRoleMapping(karpenterNodeRole, {
-            groups: ['system:bootstrapper', 'system:nodes'],
+            groups: ['system:bootstrappers', 'system:nodes'],
             username: 'system:node:{{EC2PrivateDNSName}}'
         });
 

--- a/lib/addons/karpenter/karpenter-v1.ts
+++ b/lib/addons/karpenter/karpenter-v1.ts
@@ -366,7 +366,7 @@ export class KarpenterV1AddOn extends HelmAddOn {
 
         // Map Node Role to aws-auth
         cluster.awsAuth.addRoleMapping(karpenterNodeRole, {
-            groups: ["system:bootstrapper", "system:nodes"],
+            groups: ["system:bootstrappers", "system:nodes"],
             username: "system:node:{{EC2PrivateDNSName}}",
         });
 


### PR DESCRIPTION
  ## Description

  This PR fixes a typo in the KarpenterV1AddOn that prevents Karpenter nodes from successfully joining the EKS cluster.

  ## Issue

  The addon was using `system:bootstrapper` (singular) instead of `system:bootstrappers` (plural) in the aws-auth ConfigMap configuration. This caused node registration failures with Karpenter-provisioned nodes unable to authenticate with the cluster.

  ## Changes

  - Changed `groups: ["system:bootstrapper", "system:nodes"]` to `groups: ["system:bootstrappers", "system:nodes"]` in `lib/addons/karpenter/karpenter-v1.ts`

  ## Testing

  - ✅ All existing tests pass
  - ✅ `make build` completes successfully
  - ✅ `make lint` passes
  - ✅ Verified the fix in a production EKS cluster where nodes now successfully join

  ## References

  - [Kubernetes TLS bootstrapping documentation](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/) confirms `system:bootstrappers` is the correct group name
  - [AWS EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html) shows examples using `system:bootstrappers` (plural)

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Tests pass locally
  - [x] The change is focused on a single issue
  - [x] Commit message follows conventional commits format