### PR TITLE
Add adot version mapping for EKS 1.32 and 1.33

### DIFF
--- a/lib/addons/adot/index.ts
+++ b/lib/addons/adot/index.ts
@@ -8,6 +8,8 @@ import { getAdotCollectorPolicyDocument } from "./iam-policy";
 import { KubernetesVersion } from "aws-cdk-lib/aws-eks";
 
 const versionMap: Map<KubernetesVersion, string> = new Map([
+  [KubernetesVersion.V1_33, "v0.131.0-eksbuild.1"],
+  [KubernetesVersion.V1_32, "v0.131.0-eksbuild.1"],
   [KubernetesVersion.V1_31, "v0.109.0-eksbuild.2"],
   [KubernetesVersion.V1_30, "v0.109.0-eksbuild.2"],
   [KubernetesVersion.V1_29, "v0.109.0-eksbuild.2"],


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds version mapping for ADOT in EKS 1.32 and 1.33 (both missing currently)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
